### PR TITLE
ci: add merge_group trigger to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   pull_request: {}
+  merge_group: {}
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
## Summary
- Add `merge_group: {}` trigger so CI runs in the GitHub Actions merge queue

## Test plan
- [ ] Verify build runs on merge_group events