### PR TITLE
feat(awssam): add args to env::init function signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ TODO: Add a short summary of this module.
 ##### p6df-awssam/init.zsh
 
 - `p6df::modules::awssam::deps()`
-- `p6df::modules::awssam::init()`
+- `p6df::modules::awssam::env::init(_module, _dir)`
+  - Args:
+    - _module
+    - _dir
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -17,7 +17,11 @@ p6df::modules::awssam::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::awssam::env::init()
+# Function: p6df::modules::awssam::env::init(_module, _dir)
+#
+#  Args:
+#	_module -
+#	_dir -
 #
 #  Environment:	 DOCKER_DEFAULT_PLATFORM DOCKER_HOST HOME
 #>


### PR DESCRIPTION
**What:** Add `_module`/`_dir` args to `env::init` function signature

**Why:** Aligns function signature with the established `_module`/`_dir` parameter naming convention used across p6df modules

**Test plan:** Source the module and verify `p6df::modules::awssam::env::init` accepts the expected parameters

**Dependencies:** none